### PR TITLE
relabel mounts for SELinux

### DIFF
--- a/docker-compose-infra.development.yml
+++ b/docker-compose-infra.development.yml
@@ -8,7 +8,7 @@ services:
       - "443:8005"
       - "80:8005"
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro,Z
     environment:
       LOG_FILE: "/data/access.log"
       CADDY_DOMAIN: ${CADDY_DOMAIN}

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -51,8 +51,8 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ${PLUGIN_PATH}:/app/plugins
-      - ./shared:/app/shared
+      - ${PLUGIN_PATH}:/app/plugins:z
+      - ./shared:/app/shared:z
     command: >
       sh -c "uv pip install --no-deps -e /app/shared/plugin-manager -e /app/shared/plugin-interface 
       && uv run manage.py migrate --noinput 
@@ -81,8 +81,8 @@ services:
     networks:
       - backend
     volumes:
-      - ${PLUGIN_PATH}:/app/plugins
-      - ./shared:/app/shared
+      - ${PLUGIN_PATH}:/app/plugins:z
+      - ./shared:/app/shared:z
     command: >
       sh -c "uv pip install --no-deps -e /app/shared/plugin-manager -e /app/shared/plugin-interface 
       && celery -A vera_eval.celery_worker worker --loglevel=debug"


### PR DESCRIPTION
SELinux was restricting access such as
- SELinux is preventing caddy from read access on the file Caddyfile.

Added `:z` and `:Z` for accessing plugin access and the Caddyfile respectively.