### PR TITLE
Feat/adding plugin down compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+def_plugins/

--- a/README.md
+++ b/README.md
@@ -118,3 +118,27 @@ You can run the apps with the included run configurations in `.vscode/` for **VS
 > **Note**: `backend` and `eval` will use the `env.development` files in their respective folders (`apps/backend/env.development`, `apps/eval/env.development`) when running these run configurations.
 
 > Make sure you update the **PLUGIN_PATH** in `apps/backend/env.development`, `apps/eval/env.development`
+
+#### 2.3 Run all the platform via Docker, automatically download default plugins
+
+If you want to just try the platform and play a bit with it, you can run all the infra and the application services using a single compose command.
+Before using it you need to set the GH_TOKEN env variable inside the env.plugin_downloader file. Generate a PAT from Github with valid access scope, 
+set the environment variable and run it:
+```bash
+docker compose --env-file env.plugin_downloader -f docker-compose.plugin_downloader.yml -f docker-compose-infra.development.yml -f docker-compose.development.yml up
+```
+If the PAT it valid you should see the plugins in the backend interface and also inside the def_plugin folder.
+```
+
+```
+
+
+
+
+
+
+
+
+
+
+

--- a/def_plugins/README.md
+++ b/def_plugins/README.md
@@ -1,0 +1,6 @@
+## def_plugins folder
+
+If you decide to have a test run of the platform using the plugin_downloader compose file, this folder will be used to
+store some default plugins that can be used to test/play with the platform.
+After running docker compose as mentioned in the main readme, you'll find the code of the plugins in this folder, eval and backend will
+mount it and pick up the available plugins.

--- a/docker-compose.plugin_downloader.yml
+++ b/docker-compose.plugin_downloader.yml
@@ -25,4 +25,4 @@ services:
           fi
         done
     volumes:
-      - ./${PLUGIN_PATH:?PLUGIN_PATH is required}:/downloads
+      - ${PLUGIN_PATH:?PLUGIN_PATH is required}:/downloads

--- a/docker-compose.plugin_downloader.yml
+++ b/docker-compose.plugin_downloader.yml
@@ -1,0 +1,28 @@
+services:
+  plugin-downloader:
+    image: alpine:latest
+    container_name: plugin-downloader
+    environment:
+      GH_TOKEN: ${GH_TOKEN:?GH_TOKEN is required}
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        apk --no-cache add git github-cli
+
+        cd /downloads
+
+        for repo in \
+          vera-plugin-performance \
+          vera-plugin-data-evaluation \
+          vera-plugin-llm-eval \
+          vera-plugin-counterfactual
+        do
+          if [ -d "$$repo/.git" ]; then
+            cd $$repo && gh repo sync && cd /downloads
+          else
+            gh repo clone https://github.com/lux-ai-factory/$$repo.git
+          fi
+        done
+    volumes:
+      - ./${PLUGIN_PATH:?PLUGIN_PATH is required}:/downloads

--- a/env.plugin_downloader
+++ b/env.plugin_downloader
@@ -1,0 +1,77 @@
+# UNCOMMENT this and set it to authenticate on github and clone the plugins
+#GH_TOKEN=
+
+PLUGIN_PATH=./def_plugins/
+# Minio/S3 storage location config
+#
+S3_USER=vera-s3-user
+S3_PASSWORD=dev-password
+S3_DATASETS_BUCKET=datasets
+S3_MODELS_BUCKET=models
+S3_ARTIFACTS_BUCKET=artifacts
+S3_URL=http://minio:9000
+
+# Backend config
+API_URL_EXTERNAL="http://localhost"
+CADDY_DOMAIN="http://localhost"
+CADDY_ENVIRONMENT="development"
+SHOW_PLUGIN_VISUALIZATION=true
+
+# Rabbitmq config
+RABBITMQ_USERNAME=vera-rabbit-user
+RABBITMQ_PASSWORD=dev-password
+RABBITMQ_HOST=rabbitmq
+RABBITMQ_PORT=5672
+
+# Aliasing rabbitmq config TODO: clean-up if not needed
+MQ_USERNAME=$RABBITMQ_USERNAME
+MQ_PASSWORD=$RABBITMQ_PASSWORD
+MQ_HOST=$RABBITMQ_HOST
+MQ_PORT=$RABBITMQ_PORT
+MQ_USE_SSL=false
+
+# DB configuration
+POSTGRES_USER=vera-postgres-user
+POSTGRES_PASSWORD=dev-password
+POSTGRES_DB=vera
+POSTGRES_DB_HOST=postgres
+POSTGRES_DB_PORT=5432
+#EVAL_URL_EXTERNAL=http://localhost:8001
+
+# Redis configuration
+REDIS_HOST=redis
+REDIS_USERNAME=vera-redis-user
+REDIS_PASSWORD=dev-password
+REDIS_USE_SSL=false
+REDIS_PORT=6379
+
+# Eval configuration
+CELERY_BROKER_URL=amqp://$RABBITMQ_USERNAME:$RABBITMQ_PASSWORD@$RABBITMQ_HOST:$RABBITMQ_PORT//
+REDIS_BACKEND_URL=redis://$REDIS_HOST:$REDIS_PORT/0
+API_URL=http://vera-backend:8000
+API_PREFIX=/api/v1
+CACHE_DIR=/tmp/cache
+CORS_ORIGINS=*
+
+# Aliasing Postgres config TODO: clean-up if not needed
+DB_NAME=$POSTGRES_DB
+DB_USER=$POSTGRES_USER
+DB_PASSWORD=$POSTGRES_PASSWORD
+DB_HOST=$POSTGRES_DB_HOST
+DB_PORT=$POSTGRES_DB_PORT
+
+# backend
+APP_NAME=vera-backend
+DJANGO_SECRET_KEY=your_secret_key
+DB_ENGINE=django.db.backends.postgresql
+DEBUG=False
+LOG_LEVEL=INFO
+CORS_ALLOW_ALL_ORIGINS=True
+BACKEND_CORS_ALLOWED_ORIGINS="http://localhost:5173,http://127.0.0.1:5173"
+BACKEND_CSRF_TRUSTED_ORIGINS="http://localhost:5173,http://127.0.0.1:5173"
+
+
+PACKAGE_REGISTRY_URL = http://host.docker.internal:3141
+PACKAGE_REGISTRY_USER = root
+PACKAGE_REGISTRY_PASSWORD =
+PACKAGE_REGISTRY_INDEX = root/public


### PR DESCRIPTION
This PR adds a new compose file that includes an image that will basically run a bash script and clone few plugins into a default plugins folder. The same folder destination is also set as the PLUGIN_FOLDER env var. I tested and the plugins are loaded, we need to test if each plugin is working as expected.
@fellajimed - @yulinhuang whenever you got some time could you pull the branch and run the command that I added on the readme, test if the plugins are working as expected?