### PR TITLE
fix: relabel volume mounts for SELinux

### DIFF
--- a/docker-compose-infra.development.yml
+++ b/docker-compose-infra.development.yml
@@ -100,9 +100,9 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data # Persistent storage
       # Creates the `controls` DB (apps/controls) on a fresh volume.
-      - ./init/controls-db.sql:/docker-entrypoint-initdb.d/10-controls-db.sql:ro
+      - ./init/controls-db.sql:/docker-entrypoint-initdb.d/10-controls-db.sql:ro,Z
       # Creates the `qualification` DB (apps/qualification) on a fresh volume.
-      - ./init/qualification-db.sql:/docker-entrypoint-initdb.d/20-qualification-db.sql:ro
+      - ./init/qualification-db.sql:/docker-entrypoint-initdb.d/20-qualification-db.sql:ro,Z
     restart: unless-stopped
     networks:
       - backend


### PR DESCRIPTION
Similar to #4 and #35, just a minimal change to allow for use on SELinux.